### PR TITLE
Fix problem with pattern sizing

### DIFF
--- a/lace_circular_ground.py
+++ b/lace_circular_ground.py
@@ -153,8 +153,8 @@ class CircularGround(inkex.Effect):
             'stroke-opacity': '1.0', 
             'fill-opacity': '1.0',
             'stroke': self.options.linecolor, 
-            'stroke-linecap': 'round',
-            'stroke-linejoin': 'round',
+            'stroke-linecap': 'butt',
+            'stroke-linejoin': 'butt',
             'fill': 'none'
         }
 
@@ -393,42 +393,33 @@ class CircularGround(inkex.Effect):
         inkex.Effect.__init__(self)
         # file
         self.arg_parser.add_argument('--file',
-                                     action='store',
                                      type=str,
                                      dest='file')
         # Grid description
         self.arg_parser.add_argument('--angle',
-                                     action='store',
                                      type=int,
                                      dest='angle')
         self.arg_parser.add_argument('--cols',
-                                     action='store',
                                      type=int,
                                      dest='cols')
         # Patch description
         self.arg_parser.add_argument('--diameter',
-                                     action='store',
                                      type=float,
                                      dest='diameter')
         self.arg_parser.add_argument('--diamunits',
-                                     action='store',
                                      type=str,
                                      dest='diamunits')
         self.arg_parser.add_argument('--rows',
-                                     action='store',
                                      type=int,
                                      dest='rows')
         # Line description
         self.arg_parser.add_argument('--linewidth',
-                                     action='store',
                                      type=float,
                                      dest='linewidth')
         self.arg_parser.add_argument('--lineunits',
-                                     action='store',
                                      type=str,
                                      dest='lineunits')
         self.arg_parser.add_argument('--linecolor',
-                                     action='store',
                                      type=inkex.Color,
                                      dest='linecolor')
 

--- a/lace_circular_ground.py
+++ b/lace_circular_ground.py
@@ -394,7 +394,8 @@ class CircularGround(inkex.Effect):
         # file
         self.arg_parser.add_argument('--file',
                                      type=str,
-                                     dest='file')
+                                     dest='file',
+                                     help='File containing lace ground description')
         # Grid description
         self.arg_parser.add_argument('--angle',
                                      type=int,

--- a/lace_ground.py
+++ b/lace_ground.py
@@ -115,8 +115,8 @@ class LaceGround(inkex.Effect):
             'stroke-opacity': '1.0', 
             'fill-opacity': '1.0',
             'stroke': self.options.linecolor, 
-            'stroke-linecap': 'round',
-            'stroke-linejoin': 'round',
+            'stroke-linecap': 'butt',
+            'stroke-linejoin': 'butt',
             'fill': 'none'
         }
         
@@ -172,42 +172,36 @@ class LaceGround(inkex.Effect):
         inkex.Effect.__init__(self)
 
         # file
-        self.arg_parser.add_argument('-f', '--file', action='store', type=str, dest='file', help='File containing lace ground description')
+        self.arg_parser.add_argument('-f', '--file',
+                                     type=str,
+                                     dest='file',
+                                     help='File containing lace ground description')
         # Grid description
         self.arg_parser.add_argument('--angle',
-                                     action='store',
                                      type=float,
                                      dest='angle')
         self.arg_parser.add_argument('--distance',
-                                     action='store',
                                      type=float,
                                      dest='spacing')
         self.arg_parser.add_argument('--pinunits',
-                                     action='store',
                                      type=str,
                                      dest='pinunits')
         self.arg_parser.add_argument('--width',
-                                     action='store',
                                      type=float,
                                      dest='width')
         self.arg_parser.add_argument('--patchunits',
-                                     action='store',
                                      type=str,
                                      dest='patchunits')
         self.arg_parser.add_argument('--height',
-                                     action='store',
                                      type=float,
                                      dest='height')
         self.arg_parser.add_argument('--linewidth',
-                                     action='store',
                                      type=float,
                                      dest='linewidth')
         self.arg_parser.add_argument('--lineunits',
-                                     action='store',
                                      type=str,
                                      dest='lineunits')
         self.arg_parser.add_argument('--linecolor',
-                                     action='store',
                                      type=inkex.Color,
                                      dest='linecolor')
 


### PR DESCRIPTION
The 'round' stroke style makes the pattern larger (by a small amount) than the lacemaker specified.  Use 'butt' instead.
Also, the 'store' parameter is no longer required for input arguments.