### PR TITLE
remove import of simplestyle

### DIFF
--- a/lace_circular_ground.py
+++ b/lace_circular_ground.py
@@ -27,7 +27,7 @@ import sys
 import os
 from math import sin, cos, acos, tan, radians, pi, sqrt, ceil, floor
 
-import inkex, simplestyle
+import inkex
 from lxml import etree
 
 __author__ = 'Ben Connors'

--- a/lace_ground.py
+++ b/lace_ground.py
@@ -28,7 +28,7 @@ import os
 from math import sin,cos,radians, ceil
 from lxml import etree
 
-import inkex, simplestyle
+import inkex
 
 __author__ = 'Veronika Irvine'
 __credits__ = ['Ben Connors', 'Veronika Irvine', 'Mark Shafer']


### PR DESCRIPTION
The simplestyle.py import is no longer required in Inkscape 1.0