### PR TITLE
Backward compatible upgrade for Inkscape 1.2

### DIFF
--- a/lace_circular_ground.inx
+++ b/lace_circular_ground.inx
@@ -5,7 +5,7 @@
 
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">lace_circular_ground.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <dependency type="executable" location="extensions">inkex</dependency>
 
     <param name="description" type="description" appearance="header" xml:space="preserve">Wrap lace pattern found in template file around a circle.</param>
     <param name="warning" type="description" xml:space="preserve" >Note: Drawing can become quite large when "Number of copies around circle" is small or "Diameter" of inside circle is large.</param>

--- a/lace_circular_ground.py
+++ b/lace_circular_ground.py
@@ -154,7 +154,7 @@ class CircularGround(inkex.Effect):
             'fill-opacity': '1.0',
             'stroke': self.options.linecolor, 
             'stroke-linecap': 'butt',
-            'stroke-linejoin': 'butt',
+            'stroke-linejoin': 'miter',
             'fill': 'none'
         }
 

--- a/lace_grid.inx
+++ b/lace_grid.inx
@@ -6,7 +6,7 @@
     
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">lace_grid.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <dependency type="executable" location="extensions">inkex</dependency>
     
     <param name="description" type="description" appearance="header">Creates a grid of dots of specified angle.</param>
     

--- a/lace_ground.py
+++ b/lace_ground.py
@@ -117,7 +117,7 @@ class LaceGround(inkex.Effect):
             'fill-opacity': '1.0',
             'stroke': self.options.linecolor, 
             'stroke-linecap': 'butt',
-            'stroke-linejoin': 'butt',
+            'stroke-linejoin': 'miter',
             'fill': 'none'
         }
         

--- a/lace_polar.inx
+++ b/lace_polar.inx
@@ -7,7 +7,7 @@
 	<dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
 	<dependency type="executable" location="extensions">lace_polar.py</dependency>
 	<dependency type="executable" location="extensions">simplestyle.py</dependency>
-	<dependency type="executable" location="extensions">inkex.py</dependency>
+	<dependency type="executable" location="extensions">inkex</dependency>
 	
 	<!-- title must be a single line for a left aligned layout -->
 	<param name="description" type="description">Creates a printable polar grid of dots with a constant number of dots per circle and the distance between circles changing at the same speed as the distance between the dots on a circle.</param>


### PR DESCRIPTION
Recent changes in Inkscape 1.2 prevent the extensions from launching and running.  
Tested changes against Inkscape 1.1 and Inkscape 1.2 and the changes are backward compatible.